### PR TITLE
Don't stash `originalElement` on `formElement`

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -122,15 +122,21 @@ export class FormSubmission {
   // The submission process
 
   async start() {
+    const formId = this.formElement.id
     const { initialized, requesting } = FormSubmissionState
     const confirmationMessage = getAttribute("data-turbo-confirm", this.submitter, this.formElement)
 
+    let submitter = this.submitter
+
+    if (formId) {
+      const potentialSubmitter = document.querySelector<HTMLElement>(`[data-turbo-form-id="${formId}"]`)
+
+      if (potentialSubmitter) submitter = potentialSubmitter
+    }
+
     if (typeof confirmationMessage === "string") {
-      const answer = await FormSubmission.confirmMethod(
-        confirmationMessage,
-        this.formElement,
-        this.submitter || this.formElement.originalElement
-      )
+      const answer = await FormSubmission.confirmMethod(confirmationMessage, this.formElement, submitter)
+
       if (!answer) {
         return
       }

--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -33,6 +33,10 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
   followedLinkToLocation(link: Element, location: URL): void {
     const form = document.createElement("form")
 
+    const formId = `turbo-form-${Date.now()}`
+    form.id = formId
+    link.setAttribute("data-turbo-form-id", formId)
+
     const type = "hidden"
     for (const [name, value] of location.searchParams) {
       form.append(Object.assign(document.createElement("input"), { type, name, value }))
@@ -53,10 +57,7 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
     if (turboAction) form.setAttribute("data-turbo-action", turboAction)
 
     const turboConfirm = link.getAttribute("data-turbo-confirm")
-    if (turboConfirm) {
-      form.setAttribute("data-turbo-confirm", turboConfirm)
-      form.originalElement = link
-    }
+    if (turboConfirm) form.setAttribute("data-turbo-confirm", turboConfirm)
 
     const turboStream = link.hasAttribute("data-turbo-stream")
     if (turboStream) form.setAttribute("data-turbo-stream", "")
@@ -64,7 +65,15 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
     this.delegate.submittedFormLinkToLocation(link, location, form)
 
     document.body.appendChild(form)
-    form.addEventListener("turbo:submit-end", () => form.remove(), { once: true })
+
+    form.addEventListener(
+      "turbo:submit-end",
+      () => {
+        form.remove()
+        link.removeAttribute("data-turbo-form-id")
+      },
+      { once: true }
+    )
     requestAnimationFrame(() => form.requestSubmit())
   }
 }


### PR DESCRIPTION
This approach doesn't stash a reference for the  `originalElement` on `formElement` but instead adds an ID on the `<form>` and adds a `data-turbo-form-id` attribute to the link which later is used to lookup the submitter.